### PR TITLE
Improve performance in the Test phase

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -176,7 +176,7 @@
                         <exclude>**/*IT.java</exclude>
                         <exclude>**/*IntegrationTest.java</exclude>
                     </excludes>
-                    <forkCount>1</forkCount> <!-- Higher fork counts led to unstable builds (i.e. failed test cases) -->
+                    <forkCount>1.5C</forkCount> <!-- Higher fork counts led to unstable builds (i.e. failed test cases) -->
                     <forkedProcessTimeoutInSeconds>3600</forkedProcessTimeoutInSeconds>
                     <reuseForks>false</reuseForks>
                     <argLine>-Xmx16G</argLine>


### PR DESCRIPTION

Maven will run all tests in a single forked VM by default. This can be problematic if there are a lot of tests or some very memory-hungry ones. We can fork more test VM by setting `<fork>1.5C</fork>`.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
